### PR TITLE
Suppress setup stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - mkdir release
   - cd release
   - cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_SHARED_LIBS=ON ..
-  - make all -j4 --silent
+  - make all -j4 1>/dev/null
   - sudo make install
   - sudo ldconfig
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
   - cd opencv-3.1.0
   - mkdir release
   - cd release
-  - cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_SHARED_LIBS=ON ..
+  - cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_SHARED_LIBS=ON .. 1>/dev/null
   - make all -j4 1>/dev/null
-  - sudo make install
+  - sudo make install 1>/dev/null
   - sudo ldconfig
   - cd $TRAVIS_BUILD_DIR
   - rm -rf opencv-3.1.0


### PR DESCRIPTION
from #6 

## WHY

OpenCV setup steps flush a lot of message. Therefore, the message we really want to check is difficult to find.

## WHAT

Discard messages to _stdout_ by `cmake`, `make all` and `make install`. Even if some errors occured, the error messages are shown properly.

Plz check the latest Travis CI build log.